### PR TITLE
Adjusted error code in API Error Codes example

### DIFF
--- a/docs/specifications.md
+++ b/docs/specifications.md
@@ -106,7 +106,7 @@ Find below an example error - triggered when the user did not provide a valid AP
 {
   "success": false,
   "error": {
-    "code": 104,
+    "code": 101,
     "type": "invalid_access_key",
     "info": "You have not supplied a valid API Access Key. [Technical Support: support@apilayer.net]"    
   }


### PR DESCRIPTION
Changed code from 104(usage limit) to 101(invalid access key) to match the example json error response